### PR TITLE
Fix separate reserved

### DIFF
--- a/contracts/nft-g1.sol
+++ b/contracts/nft-g1.sol
@@ -241,4 +241,12 @@ contract NFTG0RARE is Ownable, ERC721A, ReentrancyGuard {
           return _currentIndex - _startTokenId();
       }
   }
+
+    function totalReservedMinted()
+    external
+    view
+    returns (uint256)
+    {
+        return mintedReservedTokens;
+    }
 }

--- a/test/ERC721A.test.js
+++ b/test/ERC721A.test.js
@@ -137,6 +137,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
                     expect(await this.erc721a.balanceOf(this.addr1.address)).to.equal(nWhitelist);
                     expect(await this.erc721a.totalMinted()).to.equal(nBatch1 + nWhitelist);
                     expect(await this.erc721a.ownerOf(1 + nBatch1)).to.equal(this.addr1.address);
+                    expect(await this.erc721a.totalReservedMinted()).to.equal(nBatch1);
 
                     // try whitelistMint one more
                     await expect(
@@ -179,6 +180,7 @@ const createTestSuite = ({ contract, constructorArgs }) =>
                     expect(await this.erc721a.balanceOf(this.addr1.address)).to.equal(nSale);
                     expect(await this.erc721a.totalMinted()).to.equal(nBatch1 + nSale);
                     expect(await this.erc721a.ownerOf(1 + nBatch1)).to.equal(this.addr1.address);
+                    expect(await this.erc721a.totalReservedMinted()).to.equal(nBatch1);
 
                     // try mint one more
                     await expect(


### PR DESCRIPTION
Count reserved tokens and sale tokens separately, so that reserved tokens can be withdrawn at any moment

Note: contract has parameter: `maxPerAddressDuringMint`. For now it was set to 10000 and later will be parametrized in constructor in different MR